### PR TITLE
Fix: add to queue buttons

### DIFF
--- a/app/src/main/java/io/github/antoinepirlot/satunes/ui/components/dialog/music/MusicOptionsDialog.kt
+++ b/app/src/main/java/io/github/antoinepirlot/satunes/ui/components/dialog/music/MusicOptionsDialog.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import io.github.antoinepirlot.satunes.database.models.Music
@@ -56,7 +57,6 @@ internal fun MusicOptionsDialog(
     playlistWithMusics: PlaylistWithMusics? = null,
     onDismissRequest: () -> Unit,
 ) {
-
     AlertDialog(
         modifier = modifier,
         icon = {
@@ -70,6 +70,8 @@ internal fun MusicOptionsDialog(
         },
         text = {
             Column {
+                val playbackController: PlaybackController = PlaybackController.getInstance()
+                val musicPlaying: Music? by remember { playbackController.musicPlaying }
                 LikeUnlikeMusicOption(music = music)
                 AddToPlaylistOption(music = music, onFinished = onDismissRequest)
 
@@ -84,8 +86,12 @@ internal fun MusicOptionsDialog(
                 val isPlaybackLoaded: Boolean by rememberSaveable { PlaybackController.getInstance().isLoaded }
 
                 if (isPlaybackLoaded) {
-                    PlayNextMediaOption(media = music, onFinished = onDismissRequest)
-                    AddToQueueDialogOption(media = music, onFinished = onDismissRequest)
+                    if (music != musicPlaying) {
+                        PlayNextMediaOption(media = music, onFinished = onDismissRequest)
+                        if (!playbackController.isMusicInQueue(music = music)) {
+                            AddToQueueDialogOption(media = music, onFinished = onDismissRequest)
+                        }
+                    }
                 }
 
                 NavigateToMediaMusicOption(media = music.album)

--- a/playback/src/main/java/io/github/antoinepirlot/satunes/playback/models/Playlist.kt
+++ b/playback/src/main/java/io/github/antoinepirlot/satunes/playback/models/Playlist.kt
@@ -162,4 +162,8 @@ internal class Playlist(
         this.mediaItemList.add(index = newIndex, element = music.mediaItem)
     }
 
+    fun isMusicInQueue(music: Music): Boolean {
+        return this.originalMusicMediaItemMap[music] != null
+    }
+
 }

--- a/playback/src/main/java/io/github/antoinepirlot/satunes/playback/services/PlaybackController.kt
+++ b/playback/src/main/java/io/github/antoinepirlot/satunes/playback/services/PlaybackController.kt
@@ -337,6 +337,9 @@ class PlaybackController private constructor(
     }
 
     fun addNext(media: Media) {
+        if (musicPlaying.value == media) {
+            return
+        }
         when (media) {
             is Music -> {
                 try {

--- a/playback/src/main/java/io/github/antoinepirlot/satunes/playback/services/PlaybackController.kt
+++ b/playback/src/main/java/io/github/antoinepirlot/satunes/playback/services/PlaybackController.kt
@@ -537,4 +537,8 @@ class PlaybackController private constructor(
     fun getPlaylist(): SnapshotStateList<Music> {
         return this.playlist.musicList
     }
+
+    fun isMusicInQueue(music: Music): Boolean {
+        return this.playlist.isMusicInQueue(music = music)
+    }
 }


### PR DESCRIPTION
Hide both buttons if the music playing is the selected music and remove the button ad to queue if the selected music is already in the playback queue