### PR TITLE
Implement handling of shuffle media selections in AndoidAuto interface.

### DIFF
--- a/car/src/main/java/io/github/antoinepirlot/satunes/car/playback/SatunesCarCallBack.kt
+++ b/car/src/main/java/io/github/antoinepirlot/satunes/car/playback/SatunesCarCallBack.kt
@@ -83,10 +83,10 @@ internal object SatunesCarCallBack : MediaSessionCompat.Callback() {
     }
 
     override fun onPlayFromMediaId(mediaId: String, extras: Bundle?) {
-        RouteManager.setShuffleButtonSelected(selected = true)
+        if (mediaId == SatunesCarMusicService.SHUFFLE_ID)
+            RouteManager.setShuffleButtonSelected(selected = true)
         val shuffleMode: Boolean = RouteManager.isShuffleButtonSelected()
         loadMusic()
-        RouteManager.setShuffleButtonSelected(selected = false)
         var musicToPlay: Music? = null
         if (!shuffleMode) {
             musicToPlay = DataManager.getMusic(id = mediaId.toLong())


### PR DESCRIPTION
This PR resolves the issue in SatunesCarCallBack.kt discussed in Issue #1049.
It handles when the chosen media item is regular media item or if it is a "shuffle" entry.